### PR TITLE
verify the replyTo queue still exists before running the command

### DIFF
--- a/src/AMQPEndpoint.js
+++ b/src/AMQPEndpoint.js
@@ -42,8 +42,9 @@ class AMQPEndpoint {
    */
   async disconnect() {
     if (!this._channel) return;
-    await this._channel.close();
+    const channel = this._channel;
     this._channel = null;
+    await channel.close();
   }
 }
 

--- a/src/AMQPRPCClient.js
+++ b/src/AMQPRPCClient.js
@@ -106,6 +106,9 @@ class AMQPRPCClient extends AMQPEndpoint {
    * @returns {Promise}
    */
   async disconnect() {
+    if (!this._channel) {
+      return;
+    }
     await this._channel.cancel(this._consumerTag);
 
     if (this._params.repliesQueue === '') {


### PR DESCRIPTION
Add a parameter to verify if the `replyTo` queue still exists before running the command.